### PR TITLE
Updated source path to not require a collection

### DIFF
--- a/RestPS/public/Invoke-DeployRestPS.ps1
+++ b/RestPS/public/Invoke-DeployRestPS.ps1
@@ -35,7 +35,7 @@ function Invoke-DeployRestPS
             New-Item -Path "$LocalDir\endpoints\DELETE" -ItemType Directory
         }
         # Move Example files to the Local Directory
-        $Source = (Split-Path -Path (Get-Module -ListAvailable RestPS).path)[0]
+        $Source = (Split-Path -Path (Get-Module -ListAvailable RestPS | Sort-Object -Property Version -Descending | Select-Object -First 1).path)
         $RoutesFileSource = $Source + "\endpoints\Invoke-AvailableRouteSet.ps1"
         Copy-Item -Path "$RoutesFileSource" -Destination $LocalDir\Endpoints -Confirm:$false -Force
         $EndpointVerbs = @("GET", "POST", "PUT", "DELETE")


### PR DESCRIPTION
Updated the way the source path to the RestPS module is determined so that it doesn't require a collection of items (more than one version of the RestPS module to be installed). This resolves [issue 21](https://github.com/jpsider/RestPS/issues/21) that I reported.