### PR TITLE
Add plain text response

### DIFF
--- a/RestPS/private/Invoke-RequestRouter.ps1
+++ b/RestPS/private/Invoke-RequestRouter.ps1
@@ -40,6 +40,10 @@ function Invoke-RequestRouter
     {
         # Process Request
         $RequestCommand = $Route.RequestCommand
+        
+        # Grab non-default ResponseContentType for the route:
+        $script:ResponseContentType = $Route.ResponseContentType
+
         set-location $PSScriptRoot
         if ($RequestCommand -like "*.ps1")
         {

--- a/RestPS/private/Invoke-StreamOutput.ps1
+++ b/RestPS/private/Invoke-StreamOutput.ps1
@@ -8,7 +8,7 @@ function Invoke-StreamOutput
 	.NOTES
         This will returns a stream of data.
     #>
-    
+
     # Setup a placeholder to deliver a response
     $script:Response = $script:context.Response
 
@@ -19,7 +19,6 @@ function Invoke-StreamOutput
         
         # Process the Return data to send Json message back.
         $message = $script:result | ConvertTo-Json
-
     }
     else
     {

--- a/RestPS/private/Invoke-StreamOutput.ps1
+++ b/RestPS/private/Invoke-StreamOutput.ps1
@@ -2,21 +2,37 @@ function Invoke-StreamOutput
 {
     <#
 	.DESCRIPTION
-		This function will Stream output back to the Client.
+        This function will Stream output back to the Client.
 	.EXAMPLE
         Invoke-StreamOutput
 	.NOTES
         This will returns a stream of data.
     #>
-
+    
     # Setup a placeholder to deliver a response
     $script:Response = $script:context.Response
-    # Convert the returned data to JSON and set the HTTP content type to JSON
-    $script:Response.ContentType = 'application/json'
+
+    if($null -eq $script:ResponseContentType)
+    {
+        # If a response content type hasn't been defined in RestPSRoutes.json then default to JSON
+        $script:Response.ContentType = 'application/json'
+        
+        # Process the Return data to send Json message back.
+        $message = $script:result | ConvertTo-Json
+
+    }
+    else
+    {
+        # Set the content type to that defined in RestPSRoutes.json (e.g. text/plain)   
+        $script:Response.ContentType = $script:ResponseContentType
+
+        # Process the return data to send back as plain text
+        $message = $script:result
+    }
+   
     $script:Response.StatusCode = $script:StatusCode
     $script:Response.StatusDescription = $script:StatusDescription
-    # Process the Return data to send Json message back.
-    $message = $script:result | ConvertTo-Json
+   
     # Convert the data to UTF8 bytes
     [byte[]]$buffer = [System.Text.Encoding]::UTF8.GetBytes("$message")
     # Set length of response


### PR DESCRIPTION
Modification for Issue #49 

I noticed you've used quite a few script scoped variables which makes it a bit easier to 'pass' data around, so I went with that approach. Here's an example route for a plain text reply from our server:

```
  {
    "RequestType": "POST",
    "RequestURL": "/",
    "RequestCommand": "C:/RestPS/endpoints/POST/Return-Token.ps1",
    "ResponseContentType": "text/plain"
  }
```

`Invoke-RequestRouter` will attempt to grab a value for `ResponseContentType` for the route. If it's $null, then `Invoke-StreamOutput` will default to a content type of `application/json` and convert the data to JSON format for the return. Otherwise it's set to whatever the user has specified for the route and currently, returns the data as plain text.