### PR TITLE
BasicAuth: do not crash on missing Authorization header

### DIFF
--- a/RestPS/bin/Invoke-VerifyBasicAuth.ps1
+++ b/RestPS/bin/Invoke-VerifyBasicAuth.ps1
@@ -10,8 +10,13 @@ function Invoke-VerifyBasicAuth
         # Get the AuthString from Client Headers
         $ClientHeaders = $script:Request.Headers
         $ClientHeadersAuth = $ClientHeaders.GetValues("Authorization")
-        $AuthType, $AuthString = $ClientHeadersAuth.split(" ")
-        Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyBasicAuth: Auth type is: $AuthType, AuthString is: $AuthString"
+        $AuthString = $null
+
+        if ($null -ne $ClientHeadersAuth)
+        {
+            $AuthType, $AuthString = $ClientHeadersAuth.split(" ")
+            Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyBasicAuth: Auth type is: $AuthType, AuthString is: $AuthString"
+        }
 
         if ($null -ne $AuthString)
         {


### PR DESCRIPTION
`.split()` triggers an exception if `$clientHeadersAuth` is null. This can be exploited for denial of service attacks.