### PR TITLE
Removed the hardcoded endpoint/shutdown URL

### DIFF
--- a/RestPS/endpoints/RestPSRoutes.json
+++ b/RestPS/endpoints/RestPSRoutes.json
@@ -11,6 +11,11 @@
   },
   {
     "RequestType": "GET",
+    "RequestURL": "/endpoint/shutdown",
+    "RequestCommand": "$script:result = 'Shutting down RESTPS Endpoint.'; $script:StatusCode = 200; $script:status = $false"
+  },
+  {
+    "RequestType": "GET",
     "RequestURL": "/endpoint/routes",
     "RequestCommand": "c:/RestPS/endPoints/GET/Invoke-GetRoutes.ps1"
   },

--- a/RestPS/public/Start-RestPSListener.ps1
+++ b/RestPS/public/Start-RestPSListener.ps1
@@ -71,7 +71,7 @@ function Start-RestPSListener
         Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Start-RestPSListener: Calling Invoke-StartListener"
         Invoke-StartListener -Port $Port -SSLThumbPrint $SSLThumbprint -AppGuid $AppGuid
         Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Start-RestPSListener: Finished Calling Invoke-StartListener"
-        # Run until you send a GET request to /shutdown
+        # Run until you send a GET request to an endpoint, that will set $script:status to $false
         Do
         {
             # Capture requests as they come in (not Asyncronous)
@@ -134,22 +134,10 @@ function Start-RestPSListener
 
             if ($script:ProcessRequest -eq $true)
             {
-                # Break from loop if GET request sent to /shutdown
-                Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Start-RestPSListener: Processing Request, Checking for Shutdown Command"
-                if ($RequestURL -match '/EndPoint/Shutdown$')
-                {
-                    Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Start-RestPSListener: Shutting down RestEndpoint"
-                    $script:result = "Shutting down RESTPS Endpoint."
-                    $script:Status = $false
-                    $script:StatusCode = 200
-                }
-                else
-                {
-                    # Attempt to process the Request.
-                    Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Start-RestPSListener: Processing RequestType: $RequestType URL: $RequestURL Args: $RequestArgs"
-                    $script:result = Invoke-RequestRouter -RequestType "$RequestType" -RequestURL "$RequestURL" -RoutesFilePath "$RoutesFilePath" -RequestArgs "$RequestArgs"
-                    Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Start-RestPSListener: Finished request. StatusCode: $script:StatusCode StatusDesc: $Script:StatusDescription"
-                }
+                # Attempt to process the Request.
+                Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Start-RestPSListener: Processing RequestType: $RequestType URL: $RequestURL Args: $RequestArgs"
+                $script:result = Invoke-RequestRouter -RequestType "$RequestType" -RequestURL "$RequestURL" -RoutesFilePath "$RoutesFilePath" -RequestArgs "$RequestArgs"
+                Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Start-RestPSListener: Finished request. StatusCode: $script:StatusCode StatusDesc: $Script:StatusDescription"
             }
             else
             {


### PR DESCRIPTION
The hardcoded endpoint/shutdown url was a security issue, because on public servers, the server could easily be shut down. I have therefore
* removed the hardcoded url action
* added the endpoint/shutdown in the standard restpsroutes.json

So now, one can use any urlö and any additional verification before the server is shut down.