### PR TITLE
Support for (binary) file uploads

### DIFF
--- a/RestPS/endpoints/RestPSRoutes.json
+++ b/RestPS/endpoints/RestPSRoutes.json
@@ -37,7 +37,8 @@
   {
     "RequestType": "POST",
     "RequestURL": "/data",
-    "RequestCommand": "c:/RestPS/endPoints/POST/Invoke-GetProcess.ps1"
+    "RequestCommand": "c:/RestPS/endPoints/POST/Invoke-GetProcess.ps1",
+    "RequestOutputPath": "c:/RestPS/files/"
   },
   {
     "RequestType": "DELETE",

--- a/RestPS/public/Start-RestPSListener.ps1
+++ b/RestPS/public/Start-RestPSListener.ps1
@@ -127,9 +127,10 @@ function Start-RestPSListener {
                 if ($script:Request.ContentType -eq 'application/x-www-form-urlencoded' -and $RequestType -eq 'POST') {
                     if ($body) {
                         #Import routeset to get the destination file path for this route
-                        Import-RouteSet -RoutesFilePath $RoutesFilePath
-                        $Route = ($Routes | Where-Object { $null -eq $_.RequestOutputPath -and $_.RequestURL -eq $RequestURL })
+                        $script:Routes = Get-Content -Raw $RoutesFilePath | ConvertFrom-Json
+                        $Route = ($Routes | Where-Object { $null -ne $_.RequestOutputPath -and $_.RequestURL -eq $RequestURL })
                         $DestinationFilePath = $Route.RequestOutputPath
+                        Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Imported file destination for file uploads - $DestinationFilePath"
                         if ($null -eq $DestinationFilePath -or $DestinationFilePath -eq '') {
                             Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Start-RestPSListener: Destination file path on the server not correctly retrieved (510): $RequestType URL: $RequestURL Args: $RequestArgs"
                             $script:StatusDescription = "Not Extended"


### PR DESCRIPTION
This adds a way to upload files. The way I currently designed it, is by having an additional entry in the json config file that allows a file destination path set server-side. Having it set client-side with parameters would be a security issue, imo.
After the file has been uploaded to the server, the normal scripts that get invoked can be used to actually do something else with the file, such as adding it to some external database, or moving it elsewhere. 
Let me know if you like the current design, or if you prefer something else. 

Example client request:
$uri = 'http://localhost:8081/files'
$filePath = 'c:/temp/testfile.json'
$upload= Invoke-RestMethod -Uri $uri -Method Post -InFile $filePath -ContentType 'multipart/form-data'