### PR TITLE
Add a new CA verification function

### DIFF
--- a/Get-RestCAList.ps1
+++ b/Get-RestCAList.ps1
@@ -1,0 +1,16 @@
+function Get-RestCAList
+{
+    # This Function represents a way to Gather a List of accepted CA:s.
+    # it uses the value from OID 2.5.29.14 of the CA Certificate
+    
+    $CAList = @('abvvdgetgsdsgfgs','sdghjrehgfjfxdhjkgmc')
+    $CAList
+}
+
+function check-certificate
+{
+    #Set to true to enable certificate validation
+    #$checkcertificate=$false
+    $checkcertificate=$true
+    $checkcertificate
+}

--- a/Invoke-VerifyCa.ps1
+++ b/Invoke-VerifyCa.ps1
@@ -1,0 +1,70 @@
+function Invoke-VerifyCAList
+{
+
+  if ($null -ne $script:ClientCert){ 
+    
+    # Get the list over allowed CA:s
+    $CaList=""
+    Invoke-Expression (get-content -Path $RestPSLocalRoot\bin\Get-RestCAList.ps1 -raw)
+    $CaList=Get-restCAList
+	Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: CAList is: $CaList"
+    
+    if ($null -ne $CaList){
+      
+      #Get the value from the oid
+      $LocalCAIdentifier = ($script:ClientCert.Extensions | Where-Object {$_.oid.value -eq "2.5.29.35"}).format(0)
+      $LocalCAIdentifier=$LocalCAIdentifier.Substring($LocalCAIdentifier.IndexOf('=')+1)
+      Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: $LocalCAIdentifier"
+      
+      if ($null -ne $LocalCAIdentifier){
+      
+        if ($CAList.contains($LocalCAIdentifier)){
+          Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: CA is Verified."
+          
+          # Run the cert through test-certificate if check-certificate is enabled
+          if(check-certificate -eq $true){
+      
+            if(Test-Certificate $script:ClientCert -ErrorAction SilentlyContinue -WarningAction SilentlyContinue){
+              Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: certificate is Verified."
+              $script:VerifyStatus = $true
+              }
+            else
+              {
+              Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: The Certificate is not valid."
+              $script:VerifyStatus = $false
+              }
+            
+            }
+          else
+            {
+            Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: Skipping Certificate validation."
+            $script:VerifyStatus = $true
+            }  
+               
+          }
+        Else{
+          Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: CA is not allowed."
+          $script:VerifyStatus = $false
+          }
+
+        }
+      Else
+        {
+        Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: Client cert does not have a CA."
+        }
+        
+      }
+    Else
+      {
+      Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: No ACL list available."
+      }
+    
+    }
+  else
+    {
+    Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType INFO -Message "Invoke-VerifyCA: The Client did not present a certificate."
+    }
+ 
+  $script:VerifyStatus
+}		  
+		


### PR DESCRIPTION
Adds a new function for a more flexible Certificate/CA verification.  By setting $checkcertificate=$true in Get-RestCAList.ps1 the test-certificate cmdlet will be used to verify that the calling client cert is trusted by the server.

Intended to be used as a verification type.

Also decouples the server Certificate from the verification of the client cert and therefore adds support for PKI designs with more than one CA level.

Also uses Invoke-Expression (get-content -Path ...) instead of dot sourcing to speed up loading of subscripts ( dot sourcing seems to be very slow on PS 5.1).

I see further enhancements (for example dot sourcing on core (where it seems fast) and Invoke-Expression on 5.1. There are dot sourcing in more files that should be fixed too but I'll make an initial commit before I leave on vacation