### PR TITLE
Should not accept an empty ssl cert

### DIFF
--- a/RestPS/private/Invoke-StartListener.ps1
+++ b/RestPS/private/Invoke-StartListener.ps1
@@ -23,25 +23,32 @@ function Invoke-StartListener
     )
     if ($SSLThumbprint)
     {
-        # Verify the Certificate with the Specified Thumbprint is available.
-        $CertificateListCount = ((Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$_.Thumbprint -eq "$SSLThumbprint"}) | Measure-Object).Count
-        if ($CertificateListCount -ne 0)
-        {
-            # SSL Thumbprint present, enabling SSL
-            netsh http delete sslcert ipport=0.0.0.0:$Port
-            netsh http add sslcert ipport=0.0.0.0:$Port certhash=$SSLThumbprint "appid={$AppGuid}"
-            $Prefix = "https://"
-        }
-        else
-        {
-            Throw "Invoke-StartListener: Could not find Matching Certificate in CertStore: Cert:\LocalMachine"
+        if ($SSLThumbprint -eq "None"){
+	    Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Invoke-StartListener: No SSL Thumbprint present"
+            $Prefix = "http://"
+  	    }
+	else
+	   {
+	   # Verify the Certificate with the Specified Thumbprint is available.
+           $CertificateListCount = ((Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$_.Thumbprint -eq "$SSLThumbprint"}) | Measure-Object).Count
+           if ($CertificateListCount -ne 0)
+              {
+               # SSL Thumbprint present, enabling SSL
+               netsh http delete sslcert ipport=0.0.0.0:$Port
+               netsh http add sslcert ipport=0.0.0.0:$Port certhash=$SSLThumbprint "appid={$AppGuid}"
+               $Prefix = "https://"
+              }
+            else
+               {
+               Throw "Invoke-StartListener: Could not find Matching Certificate in CertStore: Cert:\LocalMachine"
+	    }
         }
     }
     else
     {
-        # No SSL Thumbprint present
-        Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Invoke-StartListener: No SSL Thumbprint present"
-        $Prefix = "http://"
+    	# parameter used but No SSL Thumbprint given
+        Throw "Invoke-StartListener: the SSLThumbPrint was used but no Thumbprint was given"
+       
     }
     try
     {

--- a/RestPS/private/Invoke-StartListener.ps1
+++ b/RestPS/private/Invoke-StartListener.ps1
@@ -24,31 +24,31 @@ function Invoke-StartListener
     if ($SSLThumbprint)
     {
         if ($SSLThumbprint -eq "None"){
-	    Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Invoke-StartListener: No SSL Thumbprint present"
+	        Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Invoke-StartListener: No SSL Thumbprint present"
             $Prefix = "http://"
   	    }
-	else
-	   {
-	   # Verify the Certificate with the Specified Thumbprint is available.
-           $CertificateListCount = ((Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$_.Thumbprint -eq "$SSLThumbprint"}) | Measure-Object).Count
-           if ($CertificateListCount -ne 0)
-              {
-               # SSL Thumbprint present, enabling SSL
-               netsh http delete sslcert ipport=0.0.0.0:$Port
-               netsh http add sslcert ipport=0.0.0.0:$Port certhash=$SSLThumbprint "appid={$AppGuid}"
-               $Prefix = "https://"
-              }
+	    else
+        {
+	        # Verify the Certificate with the Specified Thumbprint is available.
+            $CertificateListCount = ((Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$_.Thumbprint -eq "$SSLThumbprint"}) | Measure-Object).Count
+            if ($CertificateListCount -ne 0)
+            {
+                # SSL Thumbprint present, enabling SSL
+                netsh http delete sslcert ipport=0.0.0.0:$Port
+                netsh http add sslcert ipport=0.0.0.0:$Port certhash=$SSLThumbprint "appid={$AppGuid}"
+                $Prefix = "https://"
+            }
             else
-               {
-               Throw "Invoke-StartListener: Could not find Matching Certificate in CertStore: Cert:\LocalMachine"
-	    }
+            {
+                Throw "Invoke-StartListener: Could not find Matching Certificate in CertStore: Cert:\LocalMachine"
+	        }
         }
     }
     else
     {
     	# parameter used but No SSL Thumbprint given
         Throw "Invoke-StartListener: the SSLThumbPrint was used but no Thumbprint was given"
-       
+
     }
     try
     {

--- a/RestPS/public/Start-RestPSListener.ps1
+++ b/RestPS/public/Start-RestPSListener.ps1
@@ -53,7 +53,7 @@ function Start-RestPSListener
         [Parameter()][String]$RoutesFilePath = "$env:SystemDrive/RestPS/endpoints/RestPSRoutes.json",
         [Parameter()][String]$RestPSLocalRoot = "$env:SystemDrive/RestPS",
         [Parameter()][String]$Port = 8080,
-        [Parameter()][String]$SSLThumbprint,
+        [Parameter()][String]$SSLThumbprint="none",
         [Parameter()][String]$AppGuid = ((New-Guid).Guid),
         [ValidateSet("VerifyRootCA", "VerifySubject", "VerifyUserAuth", "VerifyBasicAuth")]
         [Parameter()][String]$VerificationType,


### PR DESCRIPTION
While working on my other patch I found what I think is an issue with Invoke-startlistner. 

If you call Start-RestPSListener with an empty SSLThumbprint parameter, restPS will start with a HTTP listner. 

This pull request changes this so that if the SSLThumbprint parameter is used, it also must contain a valid thumbprint.

I set  SSLThumbprint="none" as default in Invoke-StartListener.

In Invoke-startlistner I now check if SSLThumbprint="none" If so the user did not try to use SSLThumbprint and a http listner is started

If it's empty - the user used SSLThumbprint but failed to provide a cert thumbprint - thats an error
If it has a value - use the existing code to validate it