### PR TITLE
Make RawBody work again

### DIFF
--- a/RestPS/private/Invoke-GetBody.ps1
+++ b/RestPS/private/Invoke-GetBody.ps1
@@ -11,7 +11,7 @@ function Invoke-GetBody
     if ($script:Request.HasEntityBody)
     {
         $script:RawBody = $script:Request.InputStream
-        $Reader = New-Object System.IO.StreamReader @($script:RawBody, [System.Text.Encoding]::UTF8)
+        $Reader = New-Object System.IO.StreamReader @($script:RawBody, [System.Text.Encoding]::UTF8, $false, 1024, $true)
         $script:Body = $Reader.ReadToEnd()
         $Reader.close()
         $script:Body


### PR DESCRIPTION
Without the change the stream will be disposed after the reading is finished, so $script:RawBody is empty. The change just says, use no automaticBOM, use 1024 bytes Buffer and leave the stream open