### PR TITLE
Additional change for different systems

### DIFF
--- a/RestPS/private/Invoke-GetBody.ps1
+++ b/RestPS/private/Invoke-GetBody.ps1
@@ -10,10 +10,13 @@ function Invoke-GetBody
     #>
     if ($script:Request.HasEntityBody)
     {
-        $script:RawBody = $script:Request.InputStream
-        $Reader = New-Object System.IO.StreamReader @($script:RawBody, [System.Text.Encoding]::UTF8, $false, 1024, $true)
+		$script:RawBody = New-Object System.IO.MemoryStream
+		$script:Request.InputStream.CopyTo($script:RawBody)
+		$script:RawBody.Position=0
+        $Reader = New-Object System.IO.StreamReader @($script:RawBody, [System.Text.Encoding]::UTF8,$false,1024,$true)
         $script:Body = $Reader.ReadToEnd()
         $Reader.close()
+		$script:RawBody.Position=0
         $script:Body
     }
     else

--- a/RestPS/public/Start-RestPSListener.ps1
+++ b/RestPS/public/Start-RestPSListener.ps1
@@ -151,6 +151,11 @@ function Start-RestPSListener
             Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Start-RestPSListener: Streaming response back to requestor."
             Invoke-StreamOutput
             Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Start-RestPSListener: Streaming response is complete."
+			# dispose any rawstream content
+			if ($script:RawBody)
+			{
+				$script:RawBody.Dispose()
+			}
         } while ($script:Status -eq $true)
         #Terminate the listener
         Write-Log -LogFile $Logfile -LogLevel $logLevel -MsgType TRACE -Message "Start-RestPSListener: Stopping Listener."


### PR DESCRIPTION
The KeepOpen bit is working; unfortunately, whether the input stream is seekable depends on the OS/.Net version. Therefore, I have changed the code to cover all versions. The input stream is copied into a memory stream, and the RawBody and Body are created from the memory stream. This works on all systems.